### PR TITLE
Add thread title and fix remarkbox key and thread uri

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,8 @@ import { iframeResizer } from 'iframe-resizer';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
-function getRemarkboxUrl(remarkboxKey, threadUri) {
-  return `https://my.remarkbox.com/embed?rb_owner_key=${remarkboxKey}&thread_uri=${encodeURIComponent(threadUri)}`;
+function getRemarkboxUrl(remarkboxKey, threadUri, threadTitle) {
+  return `https://my.remarkbox.com/embed?rb_owner_key=${remarkboxKey}&thread_title=${encodeURIComponent(threadTitle)}&thread_uri=${encodeURIComponent(threadUri)}`;
 }
 
 class Remarkbox extends Component {
@@ -13,6 +13,7 @@ class Remarkbox extends Component {
     remarkboxKey: PropTypes.string.isRequired,
     style: PropTypes.object,
     threadFragment: PropTypes.string,
+    threadTitle: PropTypes.string.isRequired,
     threadUri: PropTypes.string.isRequired,
   };
 
@@ -41,7 +42,7 @@ class Remarkbox extends Component {
   }
 
   render() {
-    const { className, style } = this.props;
+    const { className, remarkboxKey, style, threadTitle, threadUri } = this.props;
 
     return (
       <iframe
@@ -49,7 +50,7 @@ class Remarkbox extends Component {
         frameBorder={0}
         ref={this.onRef}
         scrolling={'no'}
-        src={getRemarkboxUrl()}
+        src={getRemarkboxUrl(remarkboxKey, threadUri, threadTitle)}
         style={style}
         tabIndex={0}
         title={'Remarkbox'}


### PR DESCRIPTION
This PR adds the `threadTitle` prop. This also fixes the Remarkbox key and the thread URI that were not being used.

Closes #3 